### PR TITLE
feat(ingestion): Phase 3 – MinIO bucket notifications → RabbitMQ + uploads consumer

### DIFF
--- a/local-infra/.gitignore
+++ b/local-infra/.gitignore
@@ -26,3 +26,6 @@ coverage/
 .DS_Store
 .idea/
 .vscode/
+
+# signed-urls
+.signed-urls/

--- a/local-infra/backend/src/uploads/uploads.consumer.ts
+++ b/local-infra/backend/src/uploads/uploads.consumer.ts
@@ -1,0 +1,83 @@
+import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { RabbitMQService } from '../common/rabbitmq/rabbitmq.service';
+
+interface MinioObject {
+  key: string;
+  size?: number;
+  contentType?: string;
+}
+interface MinioRecord {
+  eventName: string; // "s3:ObjectCreated:Put" etc.
+  s3: { bucket: { name: string }; object: MinioObject };
+}
+interface MinioEvent { Records: MinioRecord[] }
+
+@Injectable()
+export class UploadsConsumer implements OnModuleInit {
+  private readonly log = new Logger(UploadsConsumer.name);
+
+  constructor(private prisma: PrismaService, private rabbit: RabbitMQService) {}
+
+  async onModuleInit() {
+    const ch = this.rabbit.channel;
+    await ch.addSetup(async (channel) => {
+      const exchange = process.env.AMQP_EXCHANGE || 'amq.direct';
+      const routingKey = process.env.AMQP_ROUTING_KEY || 'minio.uploads';
+      const queue = 'minio.uploads';
+
+      await channel.assertExchange(exchange, 'direct', { durable: true });
+      await channel.assertQueue(queue, { durable: true });
+      await channel.bindQueue(queue, exchange, routingKey);
+      await channel.prefetch(5);
+
+      await channel.consume(queue, async (msg) => {
+        if (!msg) return;
+        try {
+          const content = msg.content.toString('utf8');
+          const parsed: MinioEvent = JSON.parse(content);
+          for (const rec of parsed.Records || []) {
+            if (!rec?.s3?.object?.key) continue;
+            const inputKey = decodeURIComponent(rec.s3.object.key);
+
+            // Extract key videoId (support "<videoId>/..." o "uploads/<videoId>/...")
+            const segs = inputKey.replace(/^\/+/, '').split('/');
+            const videoId = segs[0] === 'uploads' ? segs[1] : segs[0];
+            if (!videoId) continue;
+
+            const video = await this.prisma.video.update({
+              where: { id: videoId },
+              data: { status: 'uploaded', inputKey },
+              select: { id: true, ownerId: true },
+            }).catch(() => null);
+
+            if (!video) {
+              this.log.warn(`Video not found with key=${inputKey}`);
+              continue;
+            }
+
+            // Publica evento de dominio para el transcoder
+            const domain = {
+              type: 'video.uploaded',
+              videoId: video.id,
+              ownerId: video.ownerId,
+              inputKey,
+              ts: new Date().toISOString(),
+            };
+            await channel.publish(
+              exchange,
+              'video.uploaded',
+              Buffer.from(JSON.stringify(domain)),
+              { persistent: true },
+            );
+            this.log.log(`video.uploaded → ${video.id}`);
+          }
+          channel.ack(msg);
+        } catch (e) {
+          this.log.error('Error proccesing message', e as Error);
+          channel.nack(msg, false, false); // discart (or redirect to DLQ if configured)
+        }
+      });
+    });
+  }
+}

--- a/local-infra/backend/src/uploads/uploads.module.ts
+++ b/local-infra/backend/src/uploads/uploads.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { UploadsController } from './uploads.controller';
 import { S3Module } from '../common/s3/s3.module';
+import { UploadsConsumer } from './uploads.consumer';
 
-@Module({ imports: [S3Module], controllers: [UploadsController] })
+@Module({ imports: [S3Module], controllers: [UploadsController], providers: [UploadsConsumer] })
+
 export class UploadsModule {}

--- a/local-infra/infra/docker-compose.yml
+++ b/local-infra/infra/docker-compose.yml
@@ -61,6 +61,13 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      # --- Notificaciones AMQP (slot 1) ---
+      MINIO_NOTIFY_AMQP_ENABLE_1: "on"
+      MINIO_NOTIFY_AMQP_URL_1: ${RABBITMQ_URL}
+      MINIO_NOTIFY_AMQP_EXCHANGE_1: ${AMQP_EXCHANGE}
+      MINIO_NOTIFY_AMQP_EXCHANGE_TYPE_1: "direct"
+      MINIO_NOTIFY_AMQP_ROUTING_KEY_1: ${AMQP_ROUTING_KEY}
+      MINIO_NOTIFY_AMQP_DURABLE_1: "on"
     command: ["server", "/data", "--console-address", ":9001"]
     ports:
       - "9000:9000"  # S3 API
@@ -104,7 +111,45 @@ services:
       - "7700:7700"
     volumes:
       - meili_data:/meili_data
+  
+  minio-amqp:
+    image: minio/mc:latest
+    container_name: ${COMPOSE_PROJECT_NAME}-minio-amqp
+    depends_on:
+      minio:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      MC_TTY: "0"
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      S3_BUCKET_UPLOADS: ${S3_BUCKET_UPLOADS}
+      MINIO_NOTIFY_AMQP_SLOT: ${MINIO_NOTIFY_AMQP_SLOT}
+      AMQP_URL: ${RABBITMQ_URL}
+      AMQP_EXCHANGE: ${AMQP_EXCHANGE}
+      AMQP_ROUTING_KEY: ${AMQP_ROUTING_KEY}
+      MINIO_EVENT_PREFIX: ${MINIO_EVENT_PREFIX}
+      MINIO_EVENT_SUFFIX: ${MINIO_EVENT_SUFFIX}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -euo pipefail
+        echo "Esperando MinIO..."
+        until (/usr/bin/mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1); do sleep 2; done
 
+        echo "Agregando regla de eventos en bucket $S3_BUCKET_UPLOADS (AMQP slot $MINIO_NOTIFY_AMQP_SLOT ya definido por env en MinIO)"
+        /usr/bin/mc event add local/$S3_BUCKET_UPLOADS \
+          arn:minio:sqs::${MINIO_NOTIFY_AMQP_SLOT}:amqp \
+          --event put \
+          ${MINIO_EVENT_PREFIX:+--prefix "$MINIO_EVENT_PREFIX"} \
+          ${MINIO_EVENT_SUFFIX:+--suffix "$MINIO_EVENT_SUFFIX"} || true
+
+        echo "Reglas actuales:"
+        /usr/bin/mc event list local/$S3_BUCKET_UPLOADS || true
+        echo "Listo."
+    restart: "no"
   clickhouse:
     image: clickhouse/clickhouse-server:24.3
     container_name: ${COMPOSE_PROJECT_NAME}-clickhouse


### PR DESCRIPTION
## Summary
Implements event ingestion from MinIO to RabbitMQ and a backend consumer to translate raw MinIO notifications into a domain event `video.uploaded`, updating the video record to `status='uploaded'` with its `inputKey`.

## Scope
- MinIO bucket notifications for `ObjectCreated:Put` on the `uploads` bucket.
- AMQP wiring: exchanges/queues/bindings for raw MinIO events and domain events.
- Uploads consumer: parses MinIO/S3-style event → publishes `video.uploaded { videoId, inputKey, ownerId }`.
- Videos repository: persists `inputKey` and sets status to `uploaded`.
- Idempotency basics and improved logs/metrics.

## How to test
1) Bring up Phase 1 stack (`docker compose up -d`) and the backend.
2) Ensure MinIO bucket notifications are configured for `uploads` on `ObjectCreated:Put` to the AMQP target.
3) Request a presigned POST:
`POST /v1/uploads/signed-url { filename, contentType:"video/mp4", size }`
4) Upload the file using the returned `{ url, fields }` via multipart/form-data.
5) Verify:
- RabbitMQ management UI: raw MinIO event appears in the configured queue.
- Backend logs: uploads consumer processes the message and emits `video.uploaded`.
- DB: the corresponding video record moves to `status='uploaded'` and stores `inputKey`.
-
## Definition of Done (DoD)
- [x] MinIO emits notifications on `ObjectCreated:Put` for `uploads`.
- [x] Backend consumes raw MinIO events and emits `video.uploaded`.
- [x] `videos.status` becomes `uploaded` and `inputKey` is persisted.