### PR TITLE
feat(catalog): Phase 5 – video catalog (publish/list/search) + Nginx HLS serving + video.ready consumer

### DIFF
--- a/local-infra/backend/prisma/schema.prisma
+++ b/local-infra/backend/prisma/schema.prisma
@@ -13,6 +13,11 @@ enum VideoStatus {
   ready
 }
 
+enum VideoVisibility {
+  public
+  private
+}
+
 model User {
   id        String   @id @default(uuid())
   email     String   @unique
@@ -29,6 +34,7 @@ model Video {
   title        String
   tags         String[]
   status       VideoStatus  @default(pending)
+  visibility   VideoVisibility @default(private)
   inputKey     String?
   outputPrefix String?
   thumbKey     String?
@@ -37,6 +43,9 @@ model Video {
   updatedAt    DateTime     @updatedAt
   comments     Comment[]
   likes        Like[]
+
+  @@index([status, visibility, createdAt])
+  @@index([ownerId, createdAt])
 }
 
 model Comment {

--- a/local-infra/backend/src/app.module.ts
+++ b/local-infra/backend/src/app.module.ts
@@ -8,6 +8,8 @@ import { S3Module } from './common/s3/s3.module';
 import { RedisModule } from './common/redis/redis.module';
 import { RabbitMQModule } from './common/rabbitmq/rabbitmq.module';
 import { MeiliModule } from './common/meili/meili.module';
+import { TranscodeConsumer } from './consumers/transcode.consumer';
+import { SearchModule } from './search/search.module';
 
 @Module({
   imports: [
@@ -20,6 +22,8 @@ import { MeiliModule } from './common/meili/meili.module';
     RedisModule,
     RabbitMQModule,
     MeiliModule,
+    SearchModule,
   ],
+  providers: [TranscodeConsumer],
 })
 export class AppModule {}

--- a/local-infra/backend/src/common/meili/meili.service.ts
+++ b/local-infra/backend/src/common/meili/meili.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { MeiliSearch } from 'meilisearch';
+import { MeiliSearch, Index } from 'meilisearch';
 
 @Injectable()
 export class MeiliService {
@@ -7,4 +7,19 @@ export class MeiliService {
     host: process.env.MEILI_HOST || 'http://meilisearch:7700',
     apiKey: process.env.MEILI_MASTER_KEY,
   });
+
+  async ensureVideosIndex(): Promise<Index<any>> {
+    try {
+      await this.client.getIndex('videos');
+    } catch (_) {
+      await this.client.createIndex('videos', { primaryKey: 'id' });
+    }
+    const idx = this.client.index('videos');
+    await idx.updateSettings({
+      searchableAttributes: ['title', 'tags'],
+      filterableAttributes: ['visibility', 'status', 'ownerId', 'tags'],
+      sortableAttributes: ['createdAt'],
+    });
+    return idx;
+  }
 }

--- a/local-infra/backend/src/common/rabbitmq/rabbitmq.service.ts
+++ b/local-infra/backend/src/common/rabbitmq/rabbitmq.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import amqp, { ChannelWrapper, AmqpConnectionManager } from 'amqp-connection-manager';
+import { ConfirmChannel, Options } from 'amqplib';
 
 @Injectable()
 export class RabbitMQService implements OnModuleDestroy {
@@ -10,6 +11,37 @@ export class RabbitMQService implements OnModuleDestroy {
     const url = process.env.RABBITMQ_URL || 'amqp://guest:guest@rabbitmq:5672/';
     this.connection = amqp.connect([url]);
     this.channel = this.connection.createChannel({ json: true });
+  }
+
+  async subscribe(params: {
+    exchange: string;
+    routingKey: string;
+    queue: string;
+    exchangeType?: 'direct' | 'topic' | 'fanout' | 'headers';
+    onMessage: (
+      msg: any,
+      ack: () => void,
+      retry: () => void,
+    ) => Promise<void> | void;
+  }) {
+    await this.channel.addSetup(async (ch: ConfirmChannel) => {
+      const type: Options.AssertExchange['type'] =
+        params.exchangeType || (process.env.RABBITMQ_EXCHANGE_TYPE as any) || 'direct';
+      await ch.assertExchange(params.exchange, type, { durable: true });
+      await ch.assertQueue(params.queue, { durable: true });
+      await ch.bindQueue(params.queue, params.exchange, params.routingKey);
+      await ch.consume(params.queue, async (msg) => {
+        if (!msg) return;
+        const ack = () => ch.ack(msg);
+        const retry = () => ch.nack(msg, false, true);
+        try {
+          const payload = JSON.parse(msg.content.toString());
+          await params.onMessage(payload, ack, retry);
+        } catch (e) {
+          retry();
+        }
+      }, { noAck: false });
+    });
   }
 
   async onModuleDestroy() {

--- a/local-infra/backend/src/consumers/transcode.consumer.ts
+++ b/local-infra/backend/src/consumers/transcode.consumer.ts
@@ -1,0 +1,67 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { RabbitMQService } from '../common/rabbitmq/rabbitmq.service';
+import { MeiliService } from '../common/meili/meili.service';
+
+@Injectable()
+export class TranscodeConsumer implements OnModuleInit {
+  private readonly log = new Logger(TranscodeConsumer.name);
+
+  constructor(
+    private prisma: PrismaService,
+    private mq: RabbitMQService,
+    private meili: MeiliService,
+  ) {}
+
+  async onModuleInit() {
+    const exchange = process.env.RABBITMQ_EXCHANGE || 'app.events';
+    const routingKey = process.env.RABBITMQ_ROUTING_READY || 'video.ready';
+    const queue = process.env.RABBITMQ_QUEUE_READY || 'backend.video.ready';
+
+    await this.mq.subscribe({
+      exchange,
+      routingKey,
+      queue,
+      exchangeType: (process.env.RABBITMQ_EXCHANGE_TYPE as any) || 'direct',
+      onMessage: async (evt, ack, retry) => {
+        try {
+          const { videoId, outputPrefix, thumbKey, duration } = evt;
+          if (!videoId || !outputPrefix) {
+            this.log.warn(`Evento inválido: ${JSON.stringify(evt)}`);
+            return retry();
+          }
+
+          await this.prisma.video.update({
+            where: { id: videoId },
+            data: {
+              status: 'ready',
+              outputPrefix,
+              thumbKey: thumbKey ?? null,
+              duration: typeof duration === 'number' ? duration : null,
+            },
+          });
+
+          const video = await this.prisma.video.findUnique({ where: { id: videoId } });
+          if (video) {
+            const idx = await this.meili.ensureVideosIndex();
+            await idx.addDocuments([{
+              id: video.id,
+              title: video.title,
+              tags: video.tags,
+              ownerId: video.ownerId,
+              createdAt: video.createdAt.toISOString(),
+              visibility: video.visibility,
+              status: video.status,
+            }]);
+          }
+
+          this.log.log(`video.ready indexado y actualizado: ${videoId}`);
+          ack();
+        } catch (e: any) {
+          this.log.error(e?.message || e);
+          retry();
+        }
+      },
+    });
+  }
+}

--- a/local-infra/backend/src/search/search.controller.ts
+++ b/local-infra/backend/src/search/search.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { MeiliService } from '../common/meili/meili.service';
+
+@Controller('search')
+export class SearchController {
+  constructor(private meili: MeiliService) {}
+
+  @Get()
+  async search(
+    @Query('q') q = '',
+    @Query('page') page = '1',
+    @Query('pageSize') pageSize = '20',
+  ) {
+    const p = Math.max(parseInt(page, 10) || 1, 1);
+    const ps = Math.min(Math.max(parseInt(pageSize, 10) || 20, 1), 100);
+
+    const idx = await this.meili.ensureVideosIndex();
+    const res = await idx.search(q, {
+      filter: ['visibility = public', 'status = ready'],
+      page: p,
+      hitsPerPage: ps,
+      sort: ['createdAt:desc'],
+    } as any);
+
+    return res;
+  }
+}

--- a/local-infra/backend/src/search/search.module.ts
+++ b/local-infra/backend/src/search/search.module.ts
@@ -1,0 +1,6 @@
+import { Module } from '@nestjs/common';
+import { SearchController } from './search.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({ imports: [PrismaModule], controllers: [SearchController] })
+export class SearchModule {}

--- a/local-infra/backend/src/videos/dto/publish.dto.ts
+++ b/local-infra/backend/src/videos/dto/publish.dto.ts
@@ -1,0 +1,5 @@
+import { IsIn } from 'class-validator';
+export class PublishDto {
+  @IsIn(['public', 'private'])
+  visibility!: 'public' | 'private';
+}

--- a/local-infra/backend/src/videos/videos.controller.ts
+++ b/local-infra/backend/src/videos/videos.controller.ts
@@ -1,10 +1,21 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateVideoDto } from './dto/create-video.dto';
+import { PublishDto } from './dto/publish.dto';
+import { MeiliService } from '../common/meili/meili.service';
+
+function playbackUrl(outputPrefix: string | null | undefined) {
+  const base = process.env.PUBLIC_BASE_URL || 'http://localhost:8080';
+  // Suponemos prefijo determinista: vod/hls/{videoId}/
+  if (!outputPrefix) return null;
+  const parts = outputPrefix.split('/');
+  const vid = parts.find((p) => p && p.length >= 8); // heurística mínima
+  return `${base}/hls/${vid}/master.m3u8`;
+}
 
 @Controller('videos')
 export class VideosController {
-  constructor(private prisma: PrismaService) {}
+  constructor(private prisma: PrismaService, private meili: MeiliService) {}
 
   @Post()
   async create(@Body() dto: CreateVideoDto) {
@@ -24,7 +35,85 @@ export class VideosController {
 
   @Get(':id')
   async byId(@Param('id') id: string) {
-    const video = await this.prisma.video.findUnique({ where: { id } });
-    return video ?? { error: 'not_found' };
+    const v = await this.prisma.video.findUnique({ where: { id } });
+    return v ? { ...v, hlsUrl: playbackUrl(v.outputPrefix) } : { error: 'not_found' };
+  }
+
+  @Post(':id/publish')
+  async publish(@Param('id') id: string, @Body() body: PublishDto) {
+    const v = await this.prisma.video.update({
+      where: { id },
+      data: { visibility: body.visibility },
+      select: {
+        id: true,
+        title: true,
+        tags: true,
+        ownerId: true,
+        createdAt: true,
+        visibility: true,
+        status: true,
+      },
+    });
+
+    // Upsert in Meili to reflect new visibility
+    try {
+      const idx = await this.meili.ensureVideosIndex();
+      await idx.addDocuments([
+        {
+          id: v.id,
+          title: v.title,
+          tags: v.tags,
+          ownerId: v.ownerId,
+          createdAt: v.createdAt.toISOString(),
+          visibility: v.visibility,
+          status: v.status,
+        },
+      ]);
+    } catch (_) {
+      // swallow indexing errors to not block publish
+    }
+
+    return { id: v.id, visibility: v.visibility };
+  }
+
+  @Get()
+  async list(
+    @Query('status') status = 'ready',
+    @Query('visibility') visibility: 'public' | 'private' = 'public',
+    @Query('page') page = '1',
+    @Query('pageSize') pageSize = '20',
+  ) {
+    const p = Math.max(parseInt(page, 10) || 1, 1);
+    const ps = Math.min(Math.max(parseInt(pageSize, 10) || 20, 1), 100);
+
+    const where: any = {};
+    if (status) where.status = status;
+    if (visibility) where.visibility = visibility;
+
+    const [items, total] = await Promise.all([
+      this.prisma.video.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        skip: (p - 1) * ps,
+        take: ps,
+      }),
+      this.prisma.video.count({ where }),
+    ]);
+
+    return {
+      page: p,
+      pageSize: ps,
+      total,
+      items: items.map((v) => ({
+        id: v.id,
+        title: v.title,
+        tags: v.tags,
+        thumbKey: v.thumbKey,
+        status: v.status,
+        visibility: v.visibility,
+        createdAt: v.createdAt,
+        hlsUrl: playbackUrl(v.outputPrefix),
+      })),
+    };
   }
 }

--- a/local-infra/backend/src/videos/videos.module.ts
+++ b/local-infra/backend/src/videos/videos.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { VideosController } from './videos.controller';
 import { PrismaModule } from '../prisma/prisma.module';
+import { MeiliModule } from '../common/meili/meili.module';
 
-@Module({ imports: [PrismaModule], controllers: [VideosController] })
+@Module({ imports: [PrismaModule, MeiliModule], controllers: [VideosController] })
 export class VideosModule {}

--- a/local-infra/infra/docker-compose.yml
+++ b/local-infra/infra/docker-compose.yml
@@ -194,6 +194,8 @@ services:
       MEILI_HOST: ${MEILI_HOST}
       MEILI_MASTER_KEY: ${MEILI_MASTER_KEY}
       JWT_SECRET: ${JWT_SECRET}
+      PUBLIC_BASE_URL: ${PUBLIC_BASE_URL}
+      RABBITMQ_EXCHANGE: ${AMQP_EXCHANGE}
     ports:
       - "${BACKEND_PORT}:3000"
 
@@ -246,6 +248,7 @@ services:
     volumes:
       - ../nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - hls_renditions:/var/www/hls:ro
+      - nginx_cache:/var/cache/nginx  
 
 volumes:
   pg_data:
@@ -255,6 +258,7 @@ volumes:
   meili_data:
   clickhouse_data:
   hls_renditions:
+  nginx_cache:
 
 networks:
   default:

--- a/local-infra/nginx/nginx.conf
+++ b/local-infra/nginx/nginx.conf
@@ -1,35 +1,38 @@
 worker_processes auto;
-
 error_log /var/log/nginx/error.log warn;
 pid /var/run/nginx.pid;
 
 events { worker_connections 1024; }
 
 http {
-  include       /etc/nginx/mime.types;   
+  include       /etc/nginx/mime.types;   # .m3u8 -> application/vnd.apple.mpegurl, .ts -> video/mp2t
   default_type  application/octet-stream;
-  sendfile      on;
-  tcp_nopush    on;
-  tcp_nodelay   on;
-  keepalive_timeout  65;
+  sendfile      on; tcp_nopush on; tcp_nodelay on;
+  keepalive_timeout 65;
   server_tokens off;
+
+  # Caché de HLS
+  proxy_cache_path /var/cache/nginx/hls keys_zone=HLS:10m max_size=1g inactive=24h use_temp_path=off;
+  proxy_cache_lock on;
+  proxy_cache_background_update on;
+
+  upstream minio_s3 { server minio:9000; }
 
   server {
     listen 80 default_server;
     server_name _;
+    # Serve static files if present (e.g., /var/www/hls/...)
+    root /var/www;
 
-    # CORS (include 204/4xx with 'always')
-    add_header Access-Control-Allow-Origin * always;
-    add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
-    add_header Access-Control-Allow-Headers "*" always;
+    # CORS
+    # add_header Access-Control-Allow-Origin * always;
+    # add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+    # add_header Access-Control-Allow-Headers "*" always;
 
-    # Nginx Health
-    location = /nginx-health {
-      add_header Content-Type text/plain;
-      return 200 'ok';
-    }
+    # Salud
+    location = /nginx-health { add_header Content-Type text/plain; return 200 'ok'; }
 
-    # API → backend placeholder ( OPTIONS for preflight)
+    # API backend (opcional, como en pasos previos)
     location /api/ {
       if ($request_method = OPTIONS) { return 204; }
       proxy_pass http://backend:3000/;
@@ -40,18 +43,50 @@ http {
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # HLS by volumen (OPTIONS)
+    # HLS proxy → MinIO  (mapea /hls/{id}/... a /vod/hls/{id}/...)
     location /hls/ {
       if ($request_method = OPTIONS) { return 204; }
-      alias /var/www/hls/;
-      autoindex off;
-      add_header Cache-Control "public, max-age=31536000, immutable" always; # static segments
-      # for manifests .m3u8 a short TTL
+      proxy_hide_header Access-Control-Allow-Origin;
+      proxy_hide_header Access-Control-Allow-Credentials;
+      proxy_hide_header Access-Control-Allow-Headers;
+      proxy_hide_header Access-Control-Allow-Methods;
+
+      add_header Access-Control-Allow-Origin "*" always;
+      add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS" always;
+      add_header Access-Control-Allow-Headers "Range, Origin, Accept, Referer, User-Agent" always;
+      add_header Access-Control-Expose-Headers "Content-Length, Content-Range, Accept-Ranges" always;
+      # Caché: segmentos largos, manifiestos cortos
+      proxy_cache HLS;
+      proxy_ignore_headers Set-Cookie;
+      proxy_buffering on;
+      proxy_request_buffering off;  # empieza a enviar lo que llega
+      proxy_http_version 1.1;
+      proxy_set_header Host minio:9000;            # evitar estilo virtual-host con localhost:8080
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Authorization "";          # no reenviar auth del cliente
+
+      # TTLs por tipo (override del origen)
       location ~* \.m3u8$ {
-        alias /var/www/hls/;
-        add_header Cache-Control "public, max-age=30" always;
+        proxy_cache_valid 200 206 30s;  # manifest
+        proxy_pass http://minio_s3/vod$uri;  # /hls/... -> /vod/hls/...
       }
-      try_files $uri =404;
+      location ~* \.(ts|m4s)$ {
+        proxy_cache_valid 200 206 24h;  # segmentos VOD
+        proxy_pass http://minio_s3/vod$uri;
+      }
+      # fallback genérico
+      try_files $uri @proxy_minio;
+    }
+
+    location @proxy_minio {
+      proxy_set_header Host minio:9000;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Authorization "";
+      proxy_pass http://minio_s3/vod$uri;
     }
   }
 }

--- a/transcoder/.gitignore
+++ b/transcoder/.gitignore
@@ -1,5 +1,5 @@
 # Rust / Cargo
-/target/
+/target
 **/*.rs.bk
 
 # Keep Cargo.lock tracked for apps. If this is a library,


### PR DESCRIPTION
## Summary
Delivers the video catalog capabilities and HLS serving path. When a `video.ready` event arrives, the backend updates the video record, exposes publish/list endpoints, and indexes into Meilisearch. Nginx serves HLS manifests/segments with proper MIME/CORS/caching.

## Scope
- Catalog & DB:
  - Prisma schema: fields for publish/ready (e.g., outputPrefix, thumbKey, durationSec, visibility, publishedAt), indexes.
- API:
  - POST /v1/videos/:id/publish (public|private)
  - GET  /v1/videos?status=ready&... (list/pagination)
  - GET  /v1/search?q=... (proxy to Meilisearch)
- Search:
  - SearchModule + Meilisearch helpers (ensureIndex, upsert, delete).
- Messaging:
  - RabbitMQ `subscribe()` helper + `transcode.consumer` for `video.ready`.
  - On `video.ready`: update status=ready, persist fields, upsert Meili doc.
- HLS Serving:
  - Nginx config to serve `/hls/` with correct MIME types (.m3u8/.ts), CORS, Range requests, and cache headers (short TTL for manifests, longer for segments).
- Infra:
  - docker-compose wiring to expose Nginx HLS and attach services as required.

## How to test
1) Prereqs: Phase 1–4 running (MinIO, RabbitMQ, backend v1, transcoder).
2) Produce a new video:
   - `POST /v1/uploads/signed-url` → upload `sample.mp4` to MinIO (presigned POST).
   - Backend emits `video.uploaded` → transcoder generates HLS → emits `video.ready`.
3) Verify consumer:
   - Backend logs show `video.ready` consumed.
   - DB record moves to `status = ready` and stores `outputPrefix`, `thumbKey`, `durationSec` (if available).
   - Meilisearch index has the video document.
4) Publish and list:
   - `POST /v1/videos/:id/publish { "visibility": "public" }` → 200
   - `GET  /v1/videos?status=ready&limit=10` returns the video.
   - `GET  /v1/search?q=<title or tags>` returns indexed hits.
5) HLS serving:
   - `curl -I http://localhost:8080/hls/<videoId>/master.m3u8` → 200 and `Content-Type: application/vnd.apple.mpegurl`
   - `curl -I http://localhost:8080/hls/<videoId>/out_[0-2]/...ts` → 200 and `Content-Type: video/mp2t`
   - (Optional) open a simple player (hls.js) pointing to the master.m3u8 and confirm playback.

## Definition of Done (DoD)
- [x] `video.ready` is consumed; video becomes `ready` with persisted fields.
- [x] Meilisearch index updated on ready; search endpoint returns results.
- [x] Publish endpoint toggles public/private successfully.
- [x] List endpoint returns paginated ready videos.
- [x] Nginx serves HLS with correct MIME/CORS/Range/cache headers.
- [x] Compose wiring exposes Nginx and connects required services.